### PR TITLE
fixed typo

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,5 @@
 ruby:
-  confi_file: .rubocop.yml
+  config_file: .rubocop.yml
 
 config_file:
   .jshintrc


### PR DESCRIPTION
We had spelled `config` as `confi`